### PR TITLE
feat(usuarios): restringir listagem ao perfil BIBLIOTECARIO

### DIFF
--- a/src/routes/usuarios-routes.js
+++ b/src/routes/usuarios-routes.js
@@ -8,7 +8,7 @@ const autorizar = require("../middlewares/authorize");
 
 
 // Listar usuários
-router.get('/', usuarioController.listarUsuarios);
+router.get('/', autenticar, autorizar(["BIBLIOTECARIO"]), usuarioController.listarUsuarios);
 
 // Formulário de criação de novo usuário
 router.get('/form', autenticar, autorizar(["BIBLIOTECARIO"]), usuarioController.formUsuario);


### PR DESCRIPTION
## 📌 Descrição

Adiciona controle de autorização na rota de listagem de usuários, restringindo o acesso ao perfil BIBLIOTECARIO.

## 🎯 Motivação

A rota de listagem de usuários estava acessível sem qualquer verificação de permissões, permitindo que usuários não autorizados visualizassem informações sensíveis.

## 🔧 Alterações realizadas

- Adicionado middleware `autenticar` na rota GET `/usuarios`
- Adicionado middleware `autorizar(["BIBLIOTECARIO"])` na rota GET `/usuarios`
- Garantida a proteção da listagem contra acessos indevidos

## 🧪 Como testar

1. Fazer login com usuário BIBLIOTECARIO → deve conseguir listar usuários
2. Fazer login com outro perfil → deve receber erro de autorização
3. Tentar acessar sem token → deve receber erro de autenticação

## ✅ Checklist

- [x] Código testado manualmente
- [x] Não quebra funcionalidades existentes